### PR TITLE
feat: configurable Docker Compose port via APP_PORT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Port where the app will be accessible (default: 3000)
+APP_PORT=3000

--- a/README.md
+++ b/README.md
@@ -34,11 +34,17 @@ Ver [frontend/README.md](./frontend/README.md) para más detalles.
 ### Con Docker Compose (recomendado)
 
 ```bash
+# Copiar variables de entorno
+cp .env.example .env
+
 # Desarrollo (con hot reload)
 docker compose up
 
 # Producción
 docker compose -f docker-compose.prod.yml up --build
+
+# Usar un puerto distinto (ej: 3001)
+APP_PORT=3001 docker compose up
 ```
 
 ### Local (sin Docker)
@@ -90,6 +96,7 @@ docker compose down --rmi all --volumes
 
 ### Notas
 
+- El puerto es configurable vía `APP_PORT` (default: 3000). Se puede definir en `.env` o inline: `APP_PORT=3001 docker compose up`
 - Los contenedores usan el prefijo `predictax-` (ej: `predictax-frontend`)
 - `WATCHPACK_POLLING=true` está habilitado para compatibilidad con Windows/WSL
 - En desarrollo, `src/` y `public/` se montan como volúmenes para hot reload

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile
       target: prod
     ports:
-      - "3000:3000"
+      - "${APP_PORT:-3000}:3000"
     environment:
       - NODE_ENV=production
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       dockerfile: Dockerfile
       target: dev
     ports:
-      - "3000:3000"
+      - "${APP_PORT:-3000}:3000"
     volumes:
       - ./frontend/src:/app/src
       - ./frontend/public:/app/public


### PR DESCRIPTION
## Summary
- Port is now configurable via `APP_PORT` env var (default: 3000)
- Added `.env.example` with `APP_PORT=3000`
- Updated README with usage examples

Closes #21

## Usage
```bash
# Default (port 3000)
docker compose up

# Custom port
APP_PORT=3001 docker compose up

# Or via .env file
cp .env.example .env
# edit APP_PORT in .env
docker compose up
```

## Test plan
- [ ] `docker compose up` defaults to port 3000
- [ ] `APP_PORT=3001 docker compose up` maps to port 3001
- [ ] Production compose also respects `APP_PORT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)